### PR TITLE
Add initial GitLab and GitHub CI support

### DIFF
--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -1,0 +1,48 @@
+name: OpenWrt CI testing
+
+on: [ push, pull_request ]
+env:
+  CI_ENABLE_UNIT_TESTING: 1
+  CI_TARGET_BUILD_DEPENDS: ubus libnl-tiny
+
+jobs:
+  native_testing:
+    name: Various native checks
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ynezz/gh-actions-openwrt-ci-native@v0.0.1
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: native-build-artifacts
+          if-no-files-found: ignore
+          path: |
+            build/scan
+            tests/cram/**/*.t.err
+
+  sdk_build:
+    name: Build with OpenWrt ${{ matrix.sdk_platform }} SDK (out of tree)
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk_platform:
+          - ath79-generic
+          - imx6-generic
+          - malta-be
+          - mvebu-cortexa53
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Out of tree build with OpenWrt ${{ matrix.sdk_platform }} SDK
+        uses: ynezz/gh-actions-openwrt-ci-sdk@v0.0.1
+        env:
+          CI_TARGET_SDK_RELEASE: master
+          CI_TARGET_SDK_IMAGE: ${{ matrix.sdk_platform }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+variables:
+  CI_ENABLE_UNIT_TESTING: 1
+  CI_TARGET_BUILD_DEPENDS: ubus libnl-tiny
+
+include:
+  - remote: https://gitlab.com/ynezz/openwrt-ci/raw/master/openwrt-ci/gitlab/main.yml
+  - remote: https://gitlab.com/ynezz/openwrt-ci/raw/master/openwrt-ci/gitlab/pipeline.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 2.6)
 
 PROJECT(ucentral-wifi C)
-ADD_DEFINITIONS(-Os -ggdb -Wextra -Wall -Werror --std=gnu99 -Wmissing-declarations -Wno-unused-parameter)
+
+ADD_DEFINITIONS(-Wall -Werror)
+IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+	ADD_DEFINITIONS(-Wextra -Werror=implicit-function-declaration)
+	ADD_DEFINITIONS(-Wformat -Werror=format-security -Werror=format-nonliteral)
+ENDIF()
+ADD_DEFINITIONS(-Os -std=gnu99 -g3 -Wmissing-declarations -Wno-unused-parameter)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,12 @@ SET(SOURCES main.c nl80211.c ubus.c)
 FIND_LIBRARY(ubus NAMES ubus)
 FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(nl-tiny NAMES nl-tiny)
+
+FIND_PATH(ubox_include_dir libubox/uloop.h)
 FIND_PATH(ubus_include_dir NAMES libubus.h)
-INCLUDE_DIRECTORIES(${ubox_include_dir} ${ubus_include_dir})
+FIND_PATH(libnl-tiny_include_dir netlink-generic.h PATH_SUFFIXES libnl-tiny)
+
+INCLUDE_DIRECTORIES(${ubox_include_dir} ${ubus_include_dir} ${libnl-tiny_include_dir})
 
 ADD_EXECUTABLE(ucentral-wifi ${SOURCES})
 


### PR DESCRIPTION
Uses currently proof-of-concept openwrt-ci[1] in order to:

 * improve the quality of the codebase in various areas
 * decrease code review time and help merging contributions faster
 * get automagic feedback loop on various platforms and tools
   - out of tree build with OpenWrt SDK on following targets:
     * ath79-generic
     * imx6-generic
     * malta-be
     * mvebu-cortexa53
   - out of tree native build on x86/64 with GCC (versions 8, 9, 10) and Clang 11
   - out of tree native x86/64 static code analysis with cppcheck and
     scan-build from Clang 11

1. https://gitlab.com/ynezz/openwrt-ci/