### PR TITLE
nl80211: increase IEEE80211_CHAN_MAX to 234

### DIFF
--- a/nl80211.h
+++ b/nl80211.h
@@ -10,7 +10,7 @@
 #include <libubox/avl.h>
 #include <libubox/vlist.h>
 
-#define IEEE80211_CHAN_MAX (196 + 1)
+#define IEEE80211_CHAN_MAX (233 + 1)
 
 struct wifi_phy {
 	struct avl_node avl;


### PR DESCRIPTION
The highest possible channel number across the supported frequency bands
is channel 233. Increase IEEE80211_CHAN_MAX to 233 + 1 to avoid these
errors on devices with 6GHz radios:

  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 197
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 201
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 205
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 209
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 213
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 217
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 221
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 225
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 229
  Thu Jun 16 11:20:50 2022 daemon.err ucentral-wifi: phy2: found invalid channel 233

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
